### PR TITLE
fix: compilation path resolution

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,11 +64,13 @@ module.exports = async function (source) {
     compiler.withScriptResolver(settings.scriptResolver);
   }
 
+  // Set proper context for path resolution. When including the runtime, we run `eval` and require paths to be relative to this file
+  const compilationContext = settings.includeRuntime
+    ? path.relative(__dirname, this.context)
+    : this.context;
+
   // Compile
-  let compiledCode = await compiler.compileToString(
-    input,
-    path.relative(__dirname, this.context)
-  );
+  let compiledCode = await compiler.compileToString(input, compilationContext);
 
   // Optionally transform compiled, e.g. to customize runtime
   if (settings.transformCompiled) {

--- a/index.js
+++ b/index.js
@@ -65,7 +65,10 @@ module.exports = async function (source) {
   }
 
   // Compile
-  let compiledCode = await compiler.compileToString(input, this.context);
+  let compiledCode = await compiler.compileToString(
+    input,
+    path.relative(__dirname, this.context)
+  );
 
   // Optionally transform compiled, e.g. to customize runtime
   if (settings.transformCompiled) {


### PR DESCRIPTION
Due evaluating the compiled code via `eval`, we need to make sure that resolved include paths are relative to the loader rather than relative to the template.